### PR TITLE
Add ServiceLoader for SuiteDispatcher

### DIFF
--- a/common/src/main/java/org/testng/remote/AbstractRemoteTestNG.java
+++ b/common/src/main/java/org/testng/remote/AbstractRemoteTestNG.java
@@ -1,7 +1,5 @@
 package org.testng.remote;
 
-import org.osgi.framework.Version;
-import org.osgi.framework.VersionRange;
 import org.testng.CommandLineArgs;
 import org.testng.ISuite;
 import org.testng.ISuiteListener;
@@ -40,17 +38,6 @@ public abstract class AbstractRemoteTestNG extends TestNG implements IRemoteTest
   private boolean m_dontExit;
 
   private boolean m_ack;
-
-  private final VersionRange m_range;
-
-  protected AbstractRemoteTestNG(VersionRange range) {
-    m_range = range;
-  }
-
-  @Override
-  public boolean accept(Version version) {
-    return m_range.includes(version);
-  }
 
   @Override
   public void dontExit(boolean dontExit) {

--- a/common/src/main/java/org/testng/remote/IRemoteTestNG.java
+++ b/common/src/main/java/org/testng/remote/IRemoteTestNG.java
@@ -1,6 +1,5 @@
 package org.testng.remote;
 
-import org.osgi.framework.Version;
 import org.testng.CommandLineArgs;
 
 public interface IRemoteTestNG {
@@ -14,5 +13,4 @@ public interface IRemoteTestNG {
     void setProtocol(String protocol);
     void setPort(Integer port);
     void run();
-    boolean accept(Version version);
 }

--- a/common/src/main/java/org/testng/remote/RemoteArgs.java
+++ b/common/src/main/java/org/testng/remote/RemoteArgs.java
@@ -22,13 +22,16 @@ public class RemoteArgs {
   public boolean ack = false;
 
   public static final String VERSION = "-version";
-  @Parameter(names = VERSION, description = "TestNG target version", required = true, converter = VersionConverter.class)
+  @Parameter(names = VERSION, description = "TestNG target version", converter = VersionConverter.class)
   public Version version;
 
   public static class VersionConverter implements IStringConverter<Version> {
 
     @Override
     public Version convert(String value) {
+      if (value == null) {
+        return null;
+      }
       return new Version(value);
     }
   }

--- a/common/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/common/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import org.testng.CommandLineArgs;
 import org.testng.TestNGException;
+import org.testng.remote.support.ServiceLoaderHelper;
 
 import java.util.*;
 
@@ -25,19 +26,7 @@ public class RemoteTestNG {
         RemoteArgs ra = new RemoteArgs();
         new JCommander(Arrays.asList(cla, ra), args);
 
-        List<IRemoteTestNG> remotes = new ArrayList<>();
-        for (IRemoteTestNG remote : ServiceLoader.load(IRemoteTestNG.class)) {
-            if (remote.accept(ra.version)) {
-                remotes.add(remote);
-            }
-        }
-        if (remotes.isEmpty()) {
-            throw new TestNGException(ra.version + " is not a supported TestNG version");
-        }
-        if (remotes.size() > 1) {
-            p("More than one working implementation, we will use the first one");
-        }
-        IRemoteTestNG remoteTestNg = remotes.get(0);
+        IRemoteTestNG remoteTestNg = ServiceLoaderHelper.getFirst(ra.version).createRemoteTestNG();
         remoteTestNg.dontExit(ra.dontExit);
         if (cla.port != null && ra.serPort != null) {
             throw new TestNGException("Can only specify one of " + CommandLineArgs.PORT

--- a/common/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/common/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -2,6 +2,8 @@ package org.testng.remote;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+
+import org.osgi.framework.Version;
 import org.testng.CommandLineArgs;
 import org.testng.TestNGException;
 import org.testng.remote.support.ServiceLoaderHelper;
@@ -18,6 +20,7 @@ public class RemoteTestNG {
     public static final String PROPERTY_DEBUG = "testng.eclipse.debug";
     public static final String PROPERTY_VERBOSE = "testng.eclipse.verbose";
     // End of Eclipse constants.
+    public static final String VERSION = "testng.version";
 
     private static boolean m_debug;
 
@@ -26,7 +29,9 @@ public class RemoteTestNG {
         RemoteArgs ra = new RemoteArgs();
         new JCommander(Arrays.asList(cla, ra), args);
 
-        IRemoteTestNG remoteTestNg = ServiceLoaderHelper.getFirst(ra.version).createRemoteTestNG();
+        Version testngVer = ra.version;
+        System.setProperty(VERSION, testngVer.toString());
+        IRemoteTestNG remoteTestNg = ServiceLoaderHelper.getFirst(testngVer).createRemoteTestNG();
         remoteTestNg.dontExit(ra.dontExit);
         if (cla.port != null && ra.serPort != null) {
             throw new TestNGException("Can only specify one of " + CommandLineArgs.PORT

--- a/common/src/main/java/org/testng/remote/SuiteDispatcher.java
+++ b/common/src/main/java/org/testng/remote/SuiteDispatcher.java
@@ -39,7 +39,6 @@ public class SuiteDispatcher
 	@Deprecated
 	public static final String MASTER_ADPATER = "testng.master.adpter";
 	public static final String MASTER_ADAPTER = "testng.master.adapter";
-    public static final String VERSION = "testng.version";
 
 	/**
 	 * Values allowed for STRATEGY
@@ -85,7 +84,7 @@ public class SuiteDispatcher
 			}
 			m_masterAdapter.init(properties);
 
-            String version = properties.getProperty(VERSION);
+            String version = properties.getProperty(RemoteTestNG.VERSION);
             adapter = ServiceLoaderHelper.getFirst(version == null ? null : new Version(version)).createSuiteDispatcherAdapter();
 		}
 		catch( Exception e)

--- a/common/src/main/java/org/testng/remote/support/RemoteTestNGFactory.java
+++ b/common/src/main/java/org/testng/remote/support/RemoteTestNGFactory.java
@@ -1,0 +1,11 @@
+package org.testng.remote.support;
+
+import org.osgi.framework.Version;
+import org.testng.remote.IRemoteTestNG;
+
+public interface RemoteTestNGFactory {
+
+    boolean accept(Version version);
+    SuiteDispatcherAdapter createSuiteDispatcherAdapter();
+    IRemoteTestNG createRemoteTestNG();
+}

--- a/common/src/main/java/org/testng/remote/support/ServiceLoaderHelper.java
+++ b/common/src/main/java/org/testng/remote/support/ServiceLoaderHelper.java
@@ -1,0 +1,29 @@
+package org.testng.remote.support;
+
+import org.osgi.framework.Version;
+import org.testng.TestNGException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public final class ServiceLoaderHelper {
+
+    private ServiceLoaderHelper() {}
+
+    public static RemoteTestNGFactory getFirst(Version version) {
+        List<RemoteTestNGFactory> factories = new ArrayList<>();
+        for (RemoteTestNGFactory factory : ServiceLoader.load(RemoteTestNGFactory.class)) {
+            if (factory.accept(version)) {
+                factories.add(factory);
+            }
+        }
+        if (factories.isEmpty()) {
+            throw new TestNGException(version + " is not a supported TestNG version");
+        }
+        if (factories.size() > 1) {
+            System.err.println("[ServiceLoaderHelper] More than one working implementation for '" + version + "', we will use the first one");
+        }
+        return factories.get(0);
+    }
+}

--- a/common/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter.java
+++ b/common/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter.java
@@ -1,0 +1,10 @@
+package org.testng.remote.support;
+
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+public interface SuiteDispatcherAdapter {
+
+    XmlSuite copy(XmlSuite suite, XmlTest test);
+    XmlTest copy(XmlTest test, XmlSuite suite);
+}

--- a/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNG6_5.java
+++ b/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNG6_5.java
@@ -1,49 +1,39 @@
-package org.testng.remote6_9_7;
+package org.testng.remote.support;
 
-import com.google.auto.service.AutoService;
-import org.osgi.framework.VersionRange;
+import java.util.List;
+
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ITestRunnerFactory;
 import org.testng.TestRunner;
 import org.testng.remote.AbstractRemoteTestNG;
-import org.testng.remote.IRemoteTestNG;
 import org.testng.remote.strprotocol.MessageHub;
 import org.testng.remote.strprotocol.RemoteTestListener;
 import org.testng.reporters.JUnitXMLReporter;
 import org.testng.reporters.TestHTMLReporter;
 import org.testng.xml.XmlTest;
 
-import java.util.Collection;
-
-@AutoService(IRemoteTestNG.class)
-public class RemoteTestNG extends AbstractRemoteTestNG {
-
-  private static final VersionRange RANGE = new VersionRange("[6.9.7,6.9.10)");
-
-  public RemoteTestNG() {
-    super(RANGE);
-  }
+public class RemoteTestNG6_5 extends AbstractRemoteTestNG {
 
   @Override
   protected ITestRunnerFactory buildTestRunnerFactory() {
     if(null == m_customTestRunnerFactory) {
       m_customTestRunnerFactory= new ITestRunnerFactory() {
-          @Override
-          public TestRunner newTestRunner(ISuite suite, XmlTest xmlTest,
-              Collection<IInvokedMethodListener> listeners) {
-            TestRunner runner =
-              new TestRunner(getConfiguration(), suite, xmlTest,
-                  false /*skipFailedInvocationCounts */,
-                  listeners);
-            if (m_useDefaultListeners) {
-              runner.addListener(new TestHTMLReporter());
-              runner.addListener(new JUnitXMLReporter());
-            }
-
-            return runner;
+        @Override
+        public TestRunner newTestRunner(ISuite suite, XmlTest xmlTest,
+                                        List<IInvokedMethodListener> listeners) {
+          TestRunner runner =
+                  new TestRunner(getConfiguration(), suite, xmlTest,
+                          false /*skipFailedInvocationCounts */,
+                          listeners);
+          if (m_useDefaultListeners) {
+            runner.addListener(new TestHTMLReporter());
+            runner.addListener(new JUnitXMLReporter());
           }
-        };
+
+          return runner;
+        }
+      };
     }
 
     return m_customTestRunnerFactory;
@@ -65,10 +55,11 @@ public class RemoteTestNG extends AbstractRemoteTestNG {
 
     @Override
     public TestRunner newTestRunner(ISuite suite, XmlTest test,
-        Collection<IInvokedMethodListener> listeners) {
+        List<IInvokedMethodListener> listeners) {
       TestRunner tr = m_delegateFactory.newTestRunner(suite, test, listeners);
       tr.addListener(new RemoteTestListener(suite, test, m_messageSender));
       return tr;
     }
   }
+
 }

--- a/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_5.java
+++ b/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_5.java
@@ -1,0 +1,27 @@
+package org.testng.remote.support;
+
+import com.google.auto.service.AutoService;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+import org.testng.remote.IRemoteTestNG;
+
+@AutoService(RemoteTestNGFactory.class)
+public class RemoteTestNGFactory6_5 implements RemoteTestNGFactory {
+
+    private static final VersionRange RANGE = new VersionRange("[6.5.1,6.8.1)");
+
+    @Override
+    public boolean accept(Version version) {
+        return version != null && RANGE.includes(version);
+    }
+
+    @Override
+    public SuiteDispatcherAdapter createSuiteDispatcherAdapter() {
+        return new SuiteDispatcherAdapter6_5();
+    }
+
+    @Override
+    public IRemoteTestNG createRemoteTestNG() {
+        return new RemoteTestNG6_5();
+    }
+}

--- a/remote6_5/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_5.java
+++ b/remote6_5/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_5.java
@@ -1,17 +1,12 @@
-package org.testng.remote;
+package org.testng.remote.support;
 
-import org.testng.TestNGException;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-public class SuiteDispatcher extends AbstractSuiteDispatcher {
-
-	public SuiteDispatcher(String propertiesFile) throws TestNGException {
-		super(propertiesFile);
-	}
+public class SuiteDispatcherAdapter6_5 implements SuiteDispatcherAdapter {
 
 	@Override
-	protected XmlSuite copy(XmlSuite suite, XmlTest test) {
+	public XmlSuite copy(XmlSuite suite, XmlTest test) {
 		XmlSuite tmpSuite = new XmlSuite();
 		tmpSuite.setXmlPackages(suite.getXmlPackages());
 		tmpSuite.setJUnit(suite.isJUnit());
@@ -27,7 +22,7 @@ public class SuiteDispatcher extends AbstractSuiteDispatcher {
 	}
 
 	@Override
-	protected XmlTest copy(XmlTest test, XmlSuite suite) {
+	public XmlTest copy(XmlTest test, XmlSuite suite) {
 		XmlTest tmpTest = new XmlTest(suite);
 		tmpTest.setBeanShellExpression(test.getExpression());
 		tmpTest.setXmlClasses(test.getXmlClasses());
@@ -37,7 +32,7 @@ public class SuiteDispatcher extends AbstractSuiteDispatcher {
 		tmpTest.setMethodSelectors(test.getMethodSelectors());
 		tmpTest.setName(test.getName());
 		tmpTest.setParallel(test.getParallel());
-		tmpTest.setParameters(test.getLocalParameters());
+		tmpTest.setParameters(test.getTestParameters());
 		tmpTest.setVerbose(test.getVerbose());
 		tmpTest.setXmlClasses(test.getXmlClasses());
 		tmpTest.setXmlPackages(test.getXmlPackages());

--- a/remote6_8/src/main/java/org/testng/remote/support/RemoteTestNG6_8.java
+++ b/remote6_8/src/main/java/org/testng/remote/support/RemoteTestNG6_8.java
@@ -1,30 +1,19 @@
-package org.testng.remote6_8;
+package org.testng.remote.support;
 
-import java.util.List;
-
-import org.osgi.framework.VersionRange;
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ITestRunnerFactory;
 import org.testng.TestRunner;
 import org.testng.remote.AbstractRemoteTestNG;
-import org.testng.remote.IRemoteTestNG;
 import org.testng.remote.strprotocol.MessageHub;
 import org.testng.remote.strprotocol.RemoteTestListener;
 import org.testng.reporters.JUnitXMLReporter;
 import org.testng.reporters.TestHTMLReporter;
 import org.testng.xml.XmlTest;
 
-import com.google.auto.service.AutoService;
+import java.util.List;
 
-@AutoService(IRemoteTestNG.class)
-public class RemoteTestNG extends AbstractRemoteTestNG {
-
-  private static final VersionRange RANGE = new VersionRange("[6.8.1,6.9.7)");
-
-  public RemoteTestNG() {
-    super(RANGE);
-  }
+public class RemoteTestNG6_8 extends AbstractRemoteTestNG {
 
   @Override
   protected ITestRunnerFactory buildTestRunnerFactory() {

--- a/remote6_8/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_8.java
+++ b/remote6_8/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_8.java
@@ -1,0 +1,27 @@
+package org.testng.remote.support;
+
+import com.google.auto.service.AutoService;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+import org.testng.remote.IRemoteTestNG;
+
+@AutoService(RemoteTestNGFactory.class)
+public class RemoteTestNGFactory6_8 implements RemoteTestNGFactory {
+
+    private static final VersionRange RANGE = new VersionRange("[6.8.1,6.9.7)");
+
+    @Override
+    public boolean accept(Version version) {
+        return version != null && RANGE.includes(version);
+    }
+
+    @Override
+    public SuiteDispatcherAdapter createSuiteDispatcherAdapter() {
+        return new SuiteDispatcherAdapter6_8();
+    }
+
+    @Override
+    public IRemoteTestNG createRemoteTestNG() {
+        return new RemoteTestNG6_8();
+    }
+}

--- a/remote6_8/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_8.java
+++ b/remote6_8/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_8.java
@@ -1,25 +1,18 @@
-package org.testng.remote;
+package org.testng.remote.support;
 
-import org.testng.TestNGException;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-public class SuiteDispatcher extends AbstractSuiteDispatcher {
-
-	public SuiteDispatcher(String propertiesFile) throws TestNGException {
-		super(propertiesFile);
-	}
+public class SuiteDispatcherAdapter6_8 implements SuiteDispatcherAdapter {
 
 	@Override
-	protected XmlSuite copy(XmlSuite suite, XmlTest test) {
+	public XmlSuite copy(XmlSuite suite, XmlTest test) {
 		XmlSuite tmpSuite = new XmlSuite();
 		tmpSuite.setXmlPackages(suite.getXmlPackages());
 		tmpSuite.setJUnit(suite.isJUnit());
 		tmpSuite.setSkipFailedInvocationCounts(suite.skipFailedInvocationCounts());
 		tmpSuite.setName("Temporary suite for " + test.getName());
 		tmpSuite.setParallel(suite.getParallel());
-		tmpSuite.setParentModule(suite.getParentModule());
-		tmpSuite.setGuiceStage(suite.getGuiceStage());
 		tmpSuite.setParameters(suite.getParameters());
 		tmpSuite.setThreadCount(suite.getThreadCount());
 		tmpSuite.setDataProviderThreadCount(suite.getDataProviderThreadCount());
@@ -29,7 +22,7 @@ public class SuiteDispatcher extends AbstractSuiteDispatcher {
 	}
 
 	@Override
-	protected XmlTest copy(XmlTest test, XmlSuite suite) {
+	public XmlTest copy(XmlTest test, XmlSuite suite) {
 		XmlTest tmpTest = new XmlTest(suite);
 		tmpTest.setBeanShellExpression(test.getExpression());
 		tmpTest.setXmlClasses(test.getXmlClasses());

--- a/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNG6_9_10.java
+++ b/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNG6_9_10.java
@@ -1,50 +1,41 @@
-package org.testng.remote6_5;
+package org.testng.remote.support;
 
-import java.util.List;
-
-import org.osgi.framework.VersionRange;
+import org.testng.IClassListener;
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ITestRunnerFactory;
 import org.testng.TestRunner;
 import org.testng.remote.AbstractRemoteTestNG;
-import org.testng.remote.IRemoteTestNG;
 import org.testng.remote.strprotocol.MessageHub;
 import org.testng.remote.strprotocol.RemoteTestListener;
 import org.testng.reporters.JUnitXMLReporter;
 import org.testng.reporters.TestHTMLReporter;
 import org.testng.xml.XmlTest;
 
-import com.google.auto.service.AutoService;
+import java.util.Collection;
+import java.util.List;
 
-@AutoService(IRemoteTestNG.class)
-public class RemoteTestNG extends AbstractRemoteTestNG {
-
-  private static final VersionRange RANGE = new VersionRange("[6.5.1,6.8.1)");
-
-  public RemoteTestNG() {
-    super(RANGE);
-  }
+public class RemoteTestNG6_9_10 extends AbstractRemoteTestNG {
 
   @Override
   protected ITestRunnerFactory buildTestRunnerFactory() {
     if(null == m_customTestRunnerFactory) {
       m_customTestRunnerFactory= new ITestRunnerFactory() {
-        @Override
-        public TestRunner newTestRunner(ISuite suite, XmlTest xmlTest,
-                                        List<IInvokedMethodListener> listeners) {
-          TestRunner runner =
-                  new TestRunner(getConfiguration(), suite, xmlTest,
-                          false /*skipFailedInvocationCounts */,
-                          listeners);
-          if (m_useDefaultListeners) {
-            runner.addListener(new TestHTMLReporter());
-            runner.addListener(new JUnitXMLReporter());
-          }
+          @Override
+          public TestRunner newTestRunner(ISuite suite, XmlTest xmlTest,
+              Collection<IInvokedMethodListener> listeners, List<IClassListener> classListeners) {
+            TestRunner runner =
+              new TestRunner(getConfiguration(), suite, xmlTest,
+                  false /*skipFailedInvocationCounts */,
+                  listeners, classListeners);
+            if (m_useDefaultListeners) {
+              runner.addListener(new TestHTMLReporter());
+              runner.addListener(new JUnitXMLReporter());
+            }
 
-          return runner;
-        }
-      };
+            return runner;
+          }
+        };
     }
 
     return m_customTestRunnerFactory;
@@ -66,11 +57,10 @@ public class RemoteTestNG extends AbstractRemoteTestNG {
 
     @Override
     public TestRunner newTestRunner(ISuite suite, XmlTest test,
-        List<IInvokedMethodListener> listeners) {
-      TestRunner tr = m_delegateFactory.newTestRunner(suite, test, listeners);
+        Collection<IInvokedMethodListener> listeners, List<IClassListener> classListeners) {
+      TestRunner tr = m_delegateFactory.newTestRunner(suite, test, listeners, classListeners);
       tr.addListener(new RemoteTestListener(suite, test, m_messageSender));
       return tr;
     }
   }
-
 }

--- a/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_10.java
+++ b/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_10.java
@@ -1,0 +1,27 @@
+package org.testng.remote.support;
+
+import com.google.auto.service.AutoService;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+import org.testng.remote.IRemoteTestNG;
+
+@AutoService(RemoteTestNGFactory.class)
+public class RemoteTestNGFactory6_9_10 implements RemoteTestNGFactory {
+
+    private static final VersionRange RANGE = new VersionRange("6.9.10");
+
+    @Override
+    public boolean accept(Version version) {
+        return version == null || RANGE.includes(version);
+    }
+
+    @Override
+    public SuiteDispatcherAdapter createSuiteDispatcherAdapter() {
+        return new SuiteDispatcherAdapter6_9_10();
+    }
+
+    @Override
+    public IRemoteTestNG createRemoteTestNG() {
+        return new RemoteTestNG6_9_10();
+    }
+}

--- a/remote6_9_10/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_9_10.java
+++ b/remote6_9_10/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_9_10.java
@@ -1,17 +1,12 @@
-package org.testng.remote;
+package org.testng.remote.support;
 
-import org.testng.TestNGException;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-public class SuiteDispatcher extends AbstractSuiteDispatcher {
-
-	public SuiteDispatcher(String propertiesFile) throws TestNGException {
-		super(propertiesFile);
-	}
+public class SuiteDispatcherAdapter6_9_10 implements SuiteDispatcherAdapter {
 
 	@Override
-	protected XmlSuite copy(XmlSuite suite, XmlTest test) {
+	public XmlSuite copy(XmlSuite suite, XmlTest test) {
 		XmlSuite tmpSuite = new XmlSuite();
 		tmpSuite.setXmlPackages(suite.getXmlPackages());
 		tmpSuite.setJUnit(suite.isJUnit());
@@ -27,7 +22,7 @@ public class SuiteDispatcher extends AbstractSuiteDispatcher {
 	}
 
 	@Override
-	protected XmlTest copy(XmlTest test, XmlSuite suite) {
+	public XmlTest copy(XmlTest test, XmlSuite suite) {
 		XmlTest tmpTest = new XmlTest(suite);
 		tmpTest.setBeanShellExpression(test.getExpression());
 		tmpTest.setXmlClasses(test.getXmlClasses());
@@ -37,7 +32,7 @@ public class SuiteDispatcher extends AbstractSuiteDispatcher {
 		tmpTest.setMethodSelectors(test.getMethodSelectors());
 		tmpTest.setName(test.getName());
 		tmpTest.setParallel(test.getParallel());
-		tmpTest.setParameters(test.getTestParameters());
+		tmpTest.setParameters(test.getLocalParameters());
 		tmpTest.setVerbose(test.getVerbose());
 		tmpTest.setXmlClasses(test.getXmlClasses());
 		tmpTest.setXmlPackages(test.getXmlPackages());

--- a/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNG6_9_7.java
+++ b/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNG6_9_7.java
@@ -1,14 +1,10 @@
-package org.testng.remote6_9_10;
+package org.testng.remote.support;
 
-import com.google.auto.service.AutoService;
-import org.osgi.framework.VersionRange;
-import org.testng.IClassListener;
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ITestRunnerFactory;
 import org.testng.TestRunner;
 import org.testng.remote.AbstractRemoteTestNG;
-import org.testng.remote.IRemoteTestNG;
 import org.testng.remote.strprotocol.MessageHub;
 import org.testng.remote.strprotocol.RemoteTestListener;
 import org.testng.reporters.JUnitXMLReporter;
@@ -16,16 +12,8 @@ import org.testng.reporters.TestHTMLReporter;
 import org.testng.xml.XmlTest;
 
 import java.util.Collection;
-import java.util.List;
 
-@AutoService(IRemoteTestNG.class)
-public class RemoteTestNG extends AbstractRemoteTestNG {
-
-  private static final VersionRange RANGE = new VersionRange("6.9.10");
-
-  public RemoteTestNG() {
-    super(RANGE);
-  }
+public class RemoteTestNG6_9_7 extends AbstractRemoteTestNG {
 
   @Override
   protected ITestRunnerFactory buildTestRunnerFactory() {
@@ -33,11 +21,11 @@ public class RemoteTestNG extends AbstractRemoteTestNG {
       m_customTestRunnerFactory= new ITestRunnerFactory() {
           @Override
           public TestRunner newTestRunner(ISuite suite, XmlTest xmlTest,
-              Collection<IInvokedMethodListener> listeners, List<IClassListener> classListeners) {
+              Collection<IInvokedMethodListener> listeners) {
             TestRunner runner =
               new TestRunner(getConfiguration(), suite, xmlTest,
                   false /*skipFailedInvocationCounts */,
-                  listeners, classListeners);
+                  listeners);
             if (m_useDefaultListeners) {
               runner.addListener(new TestHTMLReporter());
               runner.addListener(new JUnitXMLReporter());
@@ -67,8 +55,8 @@ public class RemoteTestNG extends AbstractRemoteTestNG {
 
     @Override
     public TestRunner newTestRunner(ISuite suite, XmlTest test,
-        Collection<IInvokedMethodListener> listeners, List<IClassListener> classListeners) {
-      TestRunner tr = m_delegateFactory.newTestRunner(suite, test, listeners, classListeners);
+        Collection<IInvokedMethodListener> listeners) {
+      TestRunner tr = m_delegateFactory.newTestRunner(suite, test, listeners);
       tr.addListener(new RemoteTestListener(suite, test, m_messageSender));
       return tr;
     }

--- a/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_7.java
+++ b/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_7.java
@@ -1,0 +1,27 @@
+package org.testng.remote.support;
+
+import com.google.auto.service.AutoService;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+import org.testng.remote.IRemoteTestNG;
+
+@AutoService(RemoteTestNGFactory.class)
+public class RemoteTestNGFactory6_9_7 implements RemoteTestNGFactory {
+
+    private static final VersionRange RANGE = new VersionRange("[6.9.7,6.9.10)");
+
+    @Override
+    public boolean accept(Version version) {
+        return version != null && RANGE.includes(version);
+    }
+
+    @Override
+    public SuiteDispatcherAdapter createSuiteDispatcherAdapter() {
+        return new SuiteDispatcherAdapter6_9_7();
+    }
+
+    @Override
+    public IRemoteTestNG createRemoteTestNG() {
+        return new RemoteTestNG6_9_7();
+    }
+}

--- a/remote6_9_7/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_9_7.java
+++ b/remote6_9_7/src/main/java/org/testng/remote/support/SuiteDispatcherAdapter6_9_7.java
@@ -1,23 +1,20 @@
-package org.testng.remote;
+package org.testng.remote.support;
 
-import org.testng.TestNGException;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-public class SuiteDispatcher extends AbstractSuiteDispatcher {
-
-	public SuiteDispatcher(String propertiesFile) throws TestNGException {
-		super(propertiesFile);
-	}
+public class SuiteDispatcherAdapter6_9_7 implements SuiteDispatcherAdapter {
 
 	@Override
-	protected XmlSuite copy(XmlSuite suite, XmlTest test) {
+	public XmlSuite copy(XmlSuite suite, XmlTest test) {
 		XmlSuite tmpSuite = new XmlSuite();
 		tmpSuite.setXmlPackages(suite.getXmlPackages());
 		tmpSuite.setJUnit(suite.isJUnit());
 		tmpSuite.setSkipFailedInvocationCounts(suite.skipFailedInvocationCounts());
 		tmpSuite.setName("Temporary suite for " + test.getName());
 		tmpSuite.setParallel(suite.getParallel());
+		tmpSuite.setParentModule(suite.getParentModule());
+		tmpSuite.setGuiceStage(suite.getGuiceStage());
 		tmpSuite.setParameters(suite.getParameters());
 		tmpSuite.setThreadCount(suite.getThreadCount());
 		tmpSuite.setDataProviderThreadCount(suite.getDataProviderThreadCount());
@@ -27,7 +24,7 @@ public class SuiteDispatcher extends AbstractSuiteDispatcher {
 	}
 
 	@Override
-	protected XmlTest copy(XmlTest test, XmlSuite suite) {
+	public XmlTest copy(XmlTest test, XmlSuite suite) {
 		XmlTest tmpTest = new XmlTest(suite);
 		tmpTest.setBeanShellExpression(test.getExpression());
 		tmpTest.setXmlClasses(test.getXmlClasses());


### PR DESCRIPTION
Sorry for the big commit.

* I moved version logic into a `RemoteTestNGFactory` => avoid duplication
* I moved support class into the same dedicated package => find more easily legacy classes and new ones in the all-in-one jar
* If no testng version is specified, the latest will be choosen