### PR TITLE
deploy snapshots to ojo-snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ jdk:
 after_success:
   - mkdir ~/.groovy
   - cp -f remote-test/src/test/resources/grapeConfig.xml ~/.groovy
-  - mvn -e clean test jacoco:report coveralls:report
+  - mkdir -p ~/.m2
+  - cp -f dist/settings.xml ~/.m2
+  - sed -i -e "s/BINTRAY_USER/${BINTRAY_USER}/g" -e "s/BINTRAY_API_KEY/${BINTRAY_API_KEY}/g" ~/.m2/settings.xml
+  - mvn -e clean deploy jacoco:report coveralls:report

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.testng</groupId>
+        <groupId>org.testng.testng-remote</groupId>
         <artifactId>testng-remote-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -14,22 +14,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote6_5</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote6_9_7</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote6_9_10</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -50,10 +50,10 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <artifactSet>
                                 <includes>
-                                    <include>org.testng:testng-remote</include>
-                                    <include>org.testng:testng-remote6_5</include>
-                                    <include>org.testng:testng-remote6_9_7</include>
-                                    <include>org.testng:testng-remote6_9_10</include>
+                                    <include>org.testng.testng-remote:testng-remote</include>
+                                    <include>org.testng.testng-remote:testng-remote6_5</include>
+                                    <include>org.testng.testng-remote:testng-remote6_9_7</include>
+                                    <include>org.testng.testng-remote:testng-remote6_9_10</include>
                                 </includes>
                             </artifactSet>
                             <transformers>

--- a/dist/settings.xml
+++ b/dist/settings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <server>
+      <id>ojo-releases</id>
+      <username>BINTRAY_USER</username>
+      <password>BINTRAY_API_KEY</password>
+    </server>
+    <server>
+      <id>ojo-snapshots</id>
+      <username>BINTRAY_USER</username>
+      <password>BINTRAY_API_KEY</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <repositories>
+        <repository>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>ojo-releases</id>
+          <name>libs-release</name>
+          <url>https://oss.jfrog.org/artifactory/libs-release</url>
+        </repository>
+        <repository>
+          <snapshots />
+          <id>ojo-snapshots</id>
+          <name>libs-snapshot</name>
+          <url>https://oss.jfrog.org/artifactory/libs-snapshot</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>central</id>
+          <name>plugins-release</name>
+          <url>https://oss.jfrog.org/artifactory/plugins-release</url>
+        </pluginRepository>
+        <pluginRepository>
+          <snapshots />
+          <id>snapshots</id>
+          <name>plugins-snapshot</name>
+          <url>https://oss.jfrog.org/artifactory/plugins-snapshot</url>
+        </pluginRepository>
+      </pluginRepositories>
+      <id>artifactory</id>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>artifactory</activeProfile>
+  </activeProfiles>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.testng</groupId>
+    <groupId>org.testng.testng-remote</groupId>
     <artifactId>testng-remote-parent</artifactId>
     <packaging>pom</packaging>
     <version>1.0.0-SNAPSHOT</version>
@@ -47,7 +47,7 @@
                 <optional>true</optional>
             </dependency>
             <dependency>
-                <groupId>org.testng</groupId>
+                <groupId>org.testng.testng-remote</groupId>
                 <artifactId>testng-remote</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -58,7 +58,7 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.testng</groupId>
+                <groupId>org.testng.testng-remote</groupId>
                 <artifactId>testng-remote</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
@@ -145,5 +145,10 @@
             <id>bintray-repo-testng-remote</id>
             <url>https://api.bintray.com/maven/testng-team/${bintray.repo}/${bintray.package}/;publish=1</url>
         </repository>
+        <snapshotRepository>
+            <id>ojo-snapshots</id>
+            <name>oss-jfrog-artifactory-snapshots</name>
+            <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+        </snapshotRepository>
     </distributionManagement>
 </project>

--- a/remote-test/pom.xml
+++ b/remote-test/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.testng</groupId>
+        <groupId>org.testng.testng-remote</groupId>
         <artifactId>testng-remote-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/remote-test/src/test/groovy/Tester.groovy
+++ b/remote-test/src/test/groovy/Tester.groovy
@@ -31,7 +31,7 @@ ivyJar = "${mvnRepoDir}/org/apache/ivy/ivy/${ivyVer}/ivy-${ivyVer}.jar"
 
 grapeRepoDir = System.getenv("HOME") + "/.groovy/grapes"
 
-remoteTestngJar = "${grapeRepoDir}/org.testng/testng-remote-dist/jars/testng-remote-dist-1.0.0-SNAPSHOT-shaded.jar"
+remoteTestngJar = "${grapeRepoDir}/org.testng.testng-remote/testng-remote-dist/jars/testng-remote-dist-1.0.0-SNAPSHOT-shaded.jar"
 jcmdJar = "${grapeRepoDir}/com.beust/jcommander/jars/jcommander-1.48.jar"
 
 resultSet = new HashMap<Integer, Set>()

--- a/remote-test/src/test/groovy/grabJar.groovy
+++ b/remote-test/src/test/groovy/grabJar.groovy
@@ -1,6 +1,6 @@
 @GrabResolver(name = 'jcenter', root = 'http://jcenter.bintray.com/')
 @Grab(group = 'org.testng', module = 'testng', version = '6.9.11')
 @Grab(group = 'com.beust', module = 'jcommander', version = '1.48')
-@Grab(group = 'org.testng', module = 'testng-remote-dist', version = '1.0.0-SNAPSHOT', classifier = 'shaded')
+@Grab(group = 'org.testng.testng-remote', module = 'testng-remote-dist', version = '1.0.0-SNAPSHOT', classifier = 'shaded')
 
 import org.testng.annotations.Test;

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.testng</groupId>
+        <groupId>org.testng.testng-remote</groupId>
         <artifactId>testng-remote-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/remote6_5/pom.xml
+++ b/remote6_5/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.testng</groupId>
+        <groupId>org.testng.testng-remote</groupId>
         <artifactId>testng-remote-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote</artifactId>
         </dependency>
         <dependency>
@@ -31,7 +31,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote</artifactId>
             <type>test-jar</type>
         </dependency>

--- a/remote6_9_10/pom.xml
+++ b/remote6_9_10/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.testng</groupId>
+        <groupId>org.testng.testng-remote</groupId>
         <artifactId>testng-remote-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote</artifactId>
         </dependency>
         <dependency>
@@ -31,7 +31,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote</artifactId>
             <type>test-jar</type>
         </dependency>

--- a/remote6_9_7/pom.xml
+++ b/remote6_9_7/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.testng</groupId>
+        <groupId>org.testng.testng-remote</groupId>
         <artifactId>testng-remote-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote</artifactId>
         </dependency>
         <dependency>
@@ -31,7 +31,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote</artifactId>
             <type>test-jar</type>
         </dependency>


### PR DESCRIPTION
for #1 , deploy the snapshots to https://oss.jfrog.org/webapp/#/artifacts/browse/tree/General/oss-snapshot-local/org/testng/testng-remote
since groupId `org.testng` already exists on OSS JFrog, I was refused to reused it. so the groupId `org.testng.testng-remote` is used instead.

<img width="1039" alt="ojo_testng_remote" src="https://cloud.githubusercontent.com/assets/555134/16551871/7ef3d90a-4171-11e6-9d2d-be46d7f8ad1d.png">