### PR TITLE
issue #29: give it 2nd chance to load the factory

### DIFF
--- a/remote-test/src/test/groovy/Tester.groovy
+++ b/remote-test/src/test/groovy/Tester.groovy
@@ -11,7 +11,6 @@ import org.testng.remote.strprotocol.JsonMessageSender
 // need to download the classifier jar for versions <= 5.11
 classifierVer = new Version("5.11")
 
-// TODO get the version properties passed by maven via system properties to be consistent with pom.xml
 groovyVer = "2.3.11"
 ivyVer = "2.3.0"
 testngRemoteVer = "1.0.1-SNAPSHOT"

--- a/remote/src/main/java/org/testng/remote/support/ServiceLoaderHelper.java
+++ b/remote/src/main/java/org/testng/remote/support/ServiceLoaderHelper.java
@@ -26,4 +26,27 @@ public final class ServiceLoaderHelper {
         }
         return factories.get(0);
     }
+
+    /**
+     * Get the first RemoteTestNGFactory.
+     * <p>
+     * this is specially for issue #29, with assumption that testng-remote jar is on front of any jar contains INDEX.LIST file.
+     * if the first RemoteTestNGFactory found, just return it.
+     * </p>
+     * @param version
+     * @return the RemoteTestNGFactory instance
+     */
+    public static RemoteTestNGFactory getFirstQuietly(Version version) {
+      try {
+        for (RemoteTestNGFactory factory : ServiceLoader.load(RemoteTestNGFactory.class)) {
+          if (factory.accept(version)) {
+              return factory;
+          }
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+
+      throw new TestNGException(version + " is not a supported TestNG version");
+  }
 }


### PR DESCRIPTION
HI @juherr 
as a workaround for issue #29, give it 2nd chance to load the factory, with assumption that testng-temote.jar on front of any jar contains INDEX.LIST (it is true in TestNG Eclipse Plugin )
