### PR TITLE
support testng version [6.0, 6.5.1) 

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -18,6 +18,10 @@
         </dependency>
         <dependency>
             <groupId>org.testng.testng-remote</groupId>
+            <artifactId>testng-remote6_0</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng.testng-remote</groupId>
             <artifactId>testng-remote6_5</artifactId>
         </dependency>
         <dependency>
@@ -46,6 +50,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.testng.testng-remote:testng-remote</include>
+                                    <include>org.testng.testng-remote:testng-remote6_0</include>
                                     <include>org.testng.testng-remote:testng-remote6_5</include>
                                     <include>org.testng.testng-remote:testng-remote6_9_7</include>
                                     <include>org.testng.testng-remote:testng-remote6_9_10</include>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>remote6_9_10</module>
         <module>remote6_9_7</module>
         <module>remote6_5</module>
+        <module>remote6_0</module>
         <module>dist</module>
         <module>remote-test</module>
     </modules>
@@ -68,6 +69,11 @@
                         <artifactId>testng</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.testng.testng-remote</groupId>
+                <artifactId>testng-remote6_0</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testng.testng-remote</groupId>

--- a/remote/src/main/java/org/testng/remote/AbstractRemoteTestNG.java
+++ b/remote/src/main/java/org/testng/remote/AbstractRemoteTestNG.java
@@ -11,8 +11,6 @@ import org.testng.xml.XmlSuite;
 
 import java.util.List;
 
-import static org.testng.internal.Utils.defaultIfStringEmpty;
-
 /**
  * Extension of TestNG registering a remote TestListener.
  *
@@ -81,6 +79,14 @@ public abstract class AbstractRemoteTestNG extends TestNG implements IRemoteTest
 
   public static void validateCommandLineParameters(CommandLineArgs args) {
     TestNG.validateCommandLineParameters(args);
+  }
+
+  public static String defaultIfStringEmpty(String s, String defaultValue) {
+    return isStringEmpty(s) ? defaultValue : s;
+  }
+
+  public static boolean isStringEmpty(String s) {
+    return s == null || "".equals(s);
   }
 
   private void calculateAllSuites(List<XmlSuite> suites, List<XmlSuite> outSuites) {

--- a/remote/src/main/java/org/testng/remote/strprotocol/RemoteTestListener.java
+++ b/remote/src/main/java/org/testng/remote/strprotocol/RemoteTestListener.java
@@ -1,7 +1,6 @@
 package org.testng.remote.strprotocol;
 
 import org.testng.ISuite;
-import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.internal.IResultListener2;
 import org.testng.xml.XmlTest;
@@ -11,109 +10,14 @@ import org.testng.xml.XmlTest;
  *
  * @author <a href='mailto:the_mindstorm[at]evolva[dot]ro'>Alexandru Popescu</a>
  */
-public class RemoteTestListener implements IResultListener2 {
-  private final MessageHub m_sender;
-  private ISuite m_suite;
-  private XmlTest m_xmlTest;
-  private ITestContext m_currentTestContext;
+public class RemoteTestListener extends RemoteTestListener1 implements IResultListener2 {
 
   public RemoteTestListener(ISuite suite, XmlTest test, MessageHub msh) {
-    m_sender = msh;
-    m_suite= suite;
-    m_xmlTest= test;
-  }
-
-  @Override
-  public void onStart(ITestContext testCtx) {
-    m_currentTestContext = testCtx;
-    m_sender.sendMessage(new TestMessage(testCtx, true /*start*/));
-  }
-
-  @Override
-  public void onFinish(ITestContext testCtx) {
-    m_sender.sendMessage(new TestMessage(testCtx, false /*end*/));
-    m_currentTestContext = null;
-  }
-
-  @Override
-  public void onTestStart(ITestResult testResult) {
-    TestResultMessage trm= null;
-
-    if (null == m_currentTestContext) {
-      trm= new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult);
-    }
-    else {
-      trm= new TestResultMessage(m_currentTestContext, testResult);
-    }
-
-    m_sender.sendMessage(trm);
+    super(suite, test, msh);
   }
 
   @Override
   public void beforeConfiguration(ITestResult tr) {
   }
 
-  @Override
-  public void onTestFailedButWithinSuccessPercentage(ITestResult testResult) {
-    if (null == m_currentTestContext) {
-      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
-    }
-    else {
-      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
-    }
-  }
-
-  @Override
-  public void onTestFailure(ITestResult testResult) {
-    if (null == m_currentTestContext) {
-      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
-    }
-    else {
-      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
-    }
-  }
-
-  @Override
-  public void onTestSkipped(ITestResult testResult) {
-    if (null == m_currentTestContext) {
-      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
-    }
-    else {
-      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
-    }
-  }
-
-  @Override
-  public void onTestSuccess(ITestResult testResult) {
-    if (null == m_currentTestContext) {
-      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
-    }
-    else {
-      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
-    }
-  }
-
-  /**
-   * @see org.testng.IConfigurationListener#onConfigurationFailure(org.testng.ITestResult)
-   */
-  @Override
-  public void onConfigurationFailure(ITestResult itr) {
-    // Show configuration failures in the main view for convenience
-    onTestFailure(itr);
-  }
-
-  /**
-   * @see org.testng.IConfigurationListener#onConfigurationSkip(org.testng.ITestResult)
-   */
-  @Override
-  public void onConfigurationSkip(ITestResult itr) {
-    onTestSkipped(itr);
-  }
-
-  /**
-   * @see org.testng.IConfigurationListener#onConfigurationSuccess(org.testng.ITestResult)
-   */
-  @Override
-  public void onConfigurationSuccess(ITestResult itr) {
-  }
 }

--- a/remote/src/main/java/org/testng/remote/strprotocol/RemoteTestListener1.java
+++ b/remote/src/main/java/org/testng/remote/strprotocol/RemoteTestListener1.java
@@ -1,21 +1,23 @@
-package org.testng.remote.support;
+package org.testng.remote.strprotocol;
 
 import org.testng.ISuite;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.internal.IResultListener;
-import org.testng.remote.strprotocol.MessageHub;
-import org.testng.remote.strprotocol.TestMessage;
-import org.testng.remote.strprotocol.TestResultMessage;
 import org.testng.xml.XmlTest;
 
-public class RemoteTestListener6_0 implements IResultListener {
+/**
+ * A special listener that remote the event with string protocol.
+ *
+ * @author <a href='mailto:the_mindstorm[at]evolva[dot]ro'>Alexandru Popescu</a>
+ */
+public class RemoteTestListener1 implements IResultListener {
   private final MessageHub m_sender;
   private ISuite m_suite;
   private XmlTest m_xmlTest;
   private ITestContext m_currentTestContext;
 
-  public RemoteTestListener6_0(ISuite suite, XmlTest test, MessageHub msh) {
+  public RemoteTestListener1(ISuite suite, XmlTest test, MessageHub msh) {
     m_sender = msh;
     m_suite= suite;
     m_xmlTest= test;

--- a/remote/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
+++ b/remote/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
@@ -119,6 +119,14 @@ public class TestResultMessage implements IStringMessage {
       stackTrace = sw.toString();
     }
 
+    String instName = "";
+    try {
+      instName = result.getInstanceName();
+    } catch (NoSuchMethodError e) {
+      // for testng version < 6.5.1
+      instName = result.getInstance().getClass().getName();
+    }
+
     init(MessageHelper.TEST_RESULT + result.getStatus(),
          suiteName,
          testName,
@@ -130,7 +138,7 @@ public class TestResultMessage implements IStringMessage {
          toString(result.getParameters(), result.getMethod().getMethod().getParameterTypes()),
          toString(result.getMethod().getMethod().getParameterTypes()),
          MessageHelper.replaceUnicodeCharactersWithAscii(result.getName()),
-         MessageHelper.replaceUnicodeCharactersWithAscii(result.getInstanceName()),
+         MessageHelper.replaceUnicodeCharactersWithAscii(instName),
          result.getMethod().getInvocationCount(),
          result.getMethod().getCurrentInvocationCount()
     );

--- a/remote6_0/pom.xml
+++ b/remote6_0/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.testng.testng-remote</groupId>
+        <artifactId>testng-remote-parent</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>testng-remote6_0</artifactId>
+    <name>TestNG Remote for version [6.0, 6.5.1)</name>
+
+    <properties>
+        <testng.version>6.0</testng.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng.testng-remote</groupId>
+            <artifactId>testng-remote</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.testng.testng-remote</groupId>
+            <artifactId>testng-remote</artifactId>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <test.resources.dir>${basedir}/../remote/target/test-classes</test.resources.dir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/remote6_0/src/main/java/org/testng/remote/support/RemoteTestListener6_0.java
+++ b/remote6_0/src/main/java/org/testng/remote/support/RemoteTestListener6_0.java
@@ -1,0 +1,113 @@
+package org.testng.remote.support;
+
+import org.testng.ISuite;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.internal.IResultListener;
+import org.testng.remote.strprotocol.MessageHub;
+import org.testng.remote.strprotocol.TestMessage;
+import org.testng.remote.strprotocol.TestResultMessage;
+import org.testng.xml.XmlTest;
+
+public class RemoteTestListener6_0 implements IResultListener {
+  private final MessageHub m_sender;
+  private ISuite m_suite;
+  private XmlTest m_xmlTest;
+  private ITestContext m_currentTestContext;
+
+  public RemoteTestListener6_0(ISuite suite, XmlTest test, MessageHub msh) {
+    m_sender = msh;
+    m_suite= suite;
+    m_xmlTest= test;
+  }
+
+  @Override
+  public void onStart(ITestContext testCtx) {
+    m_currentTestContext = testCtx;
+    m_sender.sendMessage(new TestMessage(testCtx, true /*start*/));
+  }
+
+  @Override
+  public void onFinish(ITestContext testCtx) {
+    m_sender.sendMessage(new TestMessage(testCtx, false /*end*/));
+    m_currentTestContext = null;
+  }
+
+  @Override
+  public void onTestStart(ITestResult testResult) {
+    TestResultMessage trm= null;
+
+    if (null == m_currentTestContext) {
+      trm= new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult);
+    }
+    else {
+      trm= new TestResultMessage(m_currentTestContext, testResult);
+    }
+
+    m_sender.sendMessage(trm);
+  }
+
+  @Override
+  public void onTestFailedButWithinSuccessPercentage(ITestResult testResult) {
+    if (null == m_currentTestContext) {
+      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
+    }
+    else {
+      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
+    }
+  }
+
+  @Override
+  public void onTestFailure(ITestResult testResult) {
+    if (null == m_currentTestContext) {
+      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
+    }
+    else {
+      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
+    }
+  }
+
+  @Override
+  public void onTestSkipped(ITestResult testResult) {
+    if (null == m_currentTestContext) {
+      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
+    }
+    else {
+      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
+    }
+  }
+
+  @Override
+  public void onTestSuccess(ITestResult testResult) {
+    if (null == m_currentTestContext) {
+      m_sender.sendMessage(new TestResultMessage(m_suite.getName(), m_xmlTest.getName(), testResult));
+    }
+    else {
+      m_sender.sendMessage(new TestResultMessage(m_currentTestContext, testResult));
+    }
+  }
+
+  /**
+   * @see org.testng.IConfigurationListener#onConfigurationFailure(org.testng.ITestResult)
+   */
+  @Override
+  public void onConfigurationFailure(ITestResult itr) {
+    // Show configuration failures in the main view for convenience
+    onTestFailure(itr);
+  }
+
+  /**
+   * @see org.testng.IConfigurationListener#onConfigurationSkip(org.testng.ITestResult)
+   */
+  @Override
+  public void onConfigurationSkip(ITestResult itr) {
+    onTestSkipped(itr);
+  }
+
+  /**
+   * @see org.testng.IConfigurationListener#onConfigurationSuccess(org.testng.ITestResult)
+   */
+  @Override
+  public void onConfigurationSuccess(ITestResult itr) {
+  }
+}

--- a/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNG6_0.java
+++ b/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNG6_0.java
@@ -1,0 +1,64 @@
+package org.testng.remote.support;
+
+import java.util.List;
+
+import org.testng.IInvokedMethodListener;
+import org.testng.ISuite;
+import org.testng.ITestRunnerFactory;
+import org.testng.TestRunner;
+import org.testng.remote.AbstractRemoteTestNG;
+import org.testng.remote.strprotocol.MessageHub;
+import org.testng.reporters.JUnitXMLReporter;
+import org.testng.reporters.TestHTMLReporter;
+import org.testng.xml.XmlTest;
+
+public class RemoteTestNG6_0 extends AbstractRemoteTestNG {
+
+  @Override
+  protected ITestRunnerFactory buildTestRunnerFactory() {
+    if(null == m_customTestRunnerFactory) {
+      m_customTestRunnerFactory= new ITestRunnerFactory() {
+        @Override
+        public TestRunner newTestRunner(ISuite suite, XmlTest xmlTest,
+                                        List<IInvokedMethodListener> listeners) {
+          TestRunner runner =
+                  new TestRunner(getConfiguration(), suite, xmlTest,
+                          false /*skipFailedInvocationCounts */,
+                          listeners);
+          if (m_useDefaultListeners) {
+            runner.addListener(new TestHTMLReporter());
+            runner.addListener(new JUnitXMLReporter());
+          }
+
+          return runner;
+        }
+      };
+    }
+
+    return m_customTestRunnerFactory;
+  }
+
+  @Override
+  protected ITestRunnerFactory createDelegatingTestRunnerFactory(ITestRunnerFactory trf, MessageHub smsh) {
+    return new DelegatingTestRunnerFactory(trf, smsh);
+  }
+
+  private static class DelegatingTestRunnerFactory implements ITestRunnerFactory {
+    private final ITestRunnerFactory m_delegateFactory;
+    private final MessageHub m_messageSender;
+
+    DelegatingTestRunnerFactory(ITestRunnerFactory trf, MessageHub smsh) {
+      m_delegateFactory= trf;
+      m_messageSender= smsh;
+    }
+
+    @Override
+    public TestRunner newTestRunner(ISuite suite, XmlTest test,
+        List<IInvokedMethodListener> listeners) {
+      TestRunner tr = m_delegateFactory.newTestRunner(suite, test, listeners);
+      tr.addListener(new RemoteTestListener6_0(suite, test, m_messageSender));
+      return tr;
+    }
+  }
+
+}

--- a/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNG6_0.java
+++ b/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNG6_0.java
@@ -8,6 +8,7 @@ import org.testng.ITestRunnerFactory;
 import org.testng.TestRunner;
 import org.testng.remote.AbstractRemoteTestNG;
 import org.testng.remote.strprotocol.MessageHub;
+import org.testng.remote.strprotocol.RemoteTestListener1;
 import org.testng.reporters.JUnitXMLReporter;
 import org.testng.reporters.TestHTMLReporter;
 import org.testng.xml.XmlTest;
@@ -56,7 +57,7 @@ public class RemoteTestNG6_0 extends AbstractRemoteTestNG {
     public TestRunner newTestRunner(ISuite suite, XmlTest test,
         List<IInvokedMethodListener> listeners) {
       TestRunner tr = m_delegateFactory.newTestRunner(suite, test, listeners);
-      tr.addListener(new RemoteTestListener6_0(suite, test, m_messageSender));
+      tr.addListener(new RemoteTestListener1(suite, test, m_messageSender));
       return tr;
     }
   }

--- a/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_0.java
+++ b/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_0.java
@@ -1,0 +1,23 @@
+package org.testng.remote.support;
+
+import org.osgi.framework.VersionRange;
+import org.testng.remote.AbstractRemoteTestNGFactory;
+import org.testng.remote.IRemoteTestNG;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(RemoteTestNGFactory.class)
+public class RemoteTestNGFactory6_0 extends AbstractRemoteTestNGFactory {
+
+  private static final VersionRange RANGE = new VersionRange("[6.0,6.5.1)");
+
+  @Override
+  public IRemoteTestNG createRemoteTestNG() {
+    return new RemoteTestNG6_0();
+  }
+
+  @Override
+  protected VersionRange getAcceptableVersions() {
+    return RANGE;
+  }
+}

--- a/remote6_0/src/test/java/test/remote/Remote6_0_Test.java
+++ b/remote6_0/src/test/java/test/remote/Remote6_0_Test.java
@@ -1,0 +1,10 @@
+package test.remote;
+
+public class Remote6_0_Test extends RemoteTest {
+
+  @Override
+  protected String getTestNGVersion() {
+    return "6.0";
+  }
+
+}


### PR DESCRIPTION
@juherr 
for #33, versions in [6.0, 6.5.1) are supported now.
see the output of the integration test:

```
Completed in 273204 (ms)

Summary report:
0 - PASSED:
	[6.0, 6.0.1, 6.1, 6.1.1, 6.2, 6.2.1, 6.3, 6.3.1, 6.4, 6.5.1, 6.5.2, 6.6, 6.7, 6.8, 6.8.1, 6.8.3, 6.8.5, 6.8.7, 6.8.8, 6.8.13, 6.8.14, 6.8.15, 6.8.17, 6.8.21, 6.9.4, 6.9.5, 6.9.7, 6.9.8, 6.9.9, 6.9.10, 6.9.11, 6.9.12]
1 - unsupported version detected:
	[5.13, 5.13.1, 5.14, 5.14.1, 5.14.2, 5.14.3, 5.14.4, 5.14.5, 5.14.6, 5.14.7, 5.14.9, 5.14.10]
2 - NoClassDefFoundError:
	[4.4.7, 4.6.1, 4.7, 5.0, 5.0.1, 5.0.2, 5.1, 5.5, 5.5.m, 5.6, 5.7, 5.8, 5.9, 5.10, 5.11, 5.12.1]
```