### PR TITLE
#36: Support DEV-SNAPSHOT version

### DIFF
--- a/remote/src/main/java/org/testng/remote/Orderable.java
+++ b/remote/src/main/java/org/testng/remote/Orderable.java
@@ -1,0 +1,7 @@
+package org.testng.remote;
+
+public interface Orderable {
+
+  int getOrder();
+
+}

--- a/remote/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/remote/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -13,9 +13,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 public class RemoteTestNG {
 
@@ -87,37 +90,18 @@ public class RemoteTestNG {
      */
     private static Version getTestNGVersion() {
       try {
-        // use reflection to read org.testng.internal.Version.VERSION for reason of:
-        // 1. bypass the javac compile time constant substitution
-        // 2. org.testng.internal.Version is available since version 6.6
-        @SuppressWarnings("rawtypes")
-        Class clazz = Class.forName("org.testng.internal.Version");
-        Field field = clazz.getDeclaredField("VERSION");
-        String strVer = (String) field.get(null);
-
-        return toVersion(strVer);
+        return parseVersionFromClass();
       } catch (Exception e) {
         if (isDebug()) {
           e.printStackTrace();
         }
-        p("now trying to parse the version from pom.properties");
 
-        // for testng version < 6.6, since ClassNotFound: org.testng.internal.Version, 
-        // parse the version from 'META-INF/maven/org.testng/testng/pom.properties' of testng jar on classpath
-
-        // assume this is the same classLoader loading the TestNG classes
-        ClassLoader cl = RemoteTestNG.class.getClassLoader();
-
+        Version ver = null;
         try {
-          Enumeration<URL> resources = cl.getResources(
-              "META-INF/maven/org.testng/testng/pom.properties");
-          while (resources.hasMoreElements()) {
-            Properties props = new Properties();
-            try (InputStream in = resources.nextElement().openStream()) {
-              props.load(in);
-            }
+          ver = parseVersionFromPom();
 
-            return toVersion(props.getProperty("version"));
+          if (ver == null) {
+            ver = parseVersionFromManifest();
           }
         } catch (Exception ex) {
           if (isDebug()) {
@@ -125,11 +109,8 @@ public class RemoteTestNG {
           }
         }
 
-        p("No TestNG version found on classpath");
-        if (isDebug()) {
-          if (cl instanceof URLClassLoader) {
-            p(join(((URLClassLoader) cl).getURLs(), ", "));
-          }
+        if (ver != null) {
+          return ver;
         }
       }
 
@@ -137,6 +118,91 @@ public class RemoteTestNG {
           + " Please make sure that there's a supported TestNG version (aka. >= 6.5.1) on your project.");
     }
 
+    /**
+     * use reflection to read org.testng.internal.Version.VERSION for reason of:
+     * <ul>
+     * <li>1. bypass the javac compile time constant substitution</li>
+     * <li>2. org.testng.internal.Version is available since version 6.6</li>
+     * </ul>
+     * 
+     * @return
+     * @throws Exception
+     */
+    private static Version parseVersionFromClass() throws Exception {
+      @SuppressWarnings("rawtypes")
+      Class clazz = Class.forName("org.testng.internal.Version");
+      Field field = clazz.getDeclaredField("VERSION");
+      String strVer = (String) field.get(null);
+
+      return toVersion(strVer);
+    }
+
+    /**
+     * Parse the version from pom.properties.
+     * <p>
+     * for testng version < 6.6, since ClassNotFound: org.testng.internal.Version,
+     * parse the version from 'META-INF/maven/org.testng/testng/pom.properties' of testng jar on classpath
+     * </p>
+     * 
+     * @return the testng version, or {@code null} if not found.
+     * @throws Exception
+     */
+    private static Version parseVersionFromPom() throws Exception {
+      p("now trying to parse the version from pom.properties");
+
+      // assume this is the same classLoader loading the TestNG classes
+      ClassLoader cl = RemoteTestNG.class.getClassLoader();
+
+      Enumeration<URL> resources = cl.getResources(
+          "META-INF/maven/org.testng/testng/pom.properties");
+      while (resources.hasMoreElements()) {
+        Properties props = new Properties();
+        try (InputStream in = resources.nextElement().openStream()) {
+          props.load(in);
+        }
+
+        return toVersion(props.getProperty("version"));
+      }
+
+      return null;
+    }
+
+    /**
+     * Parse the version from MANIFEST.MF
+     * <p>
+     * in PR https://github.com/cbeust/testng/pull/1124, `public static final String VERSION = "DEV-SNAPSHOT";`, 
+     * method {@link #parseVersionFromClass()} can't get the exact version when launch the tests of TestNG itself in Eclipse,
+     * the workaround here is to parse the MANIFEST.MF to get the version.
+     * </p>
+     * 
+     * @return the testng version, or {@code null} if not found.
+     * @throws Exception
+     */
+    private static Version parseVersionFromManifest() throws Exception {
+      p("now trying to parse the version from MANIFEST.MF");
+
+      ClassLoader cl = RemoteTestNG.class.getClassLoader();
+
+      Enumeration<URL> resources = cl.getResources("META-INF/MANIFEST.MF");
+      while (resources.hasMoreElements()) {
+        Manifest mf = new Manifest(resources.nextElement().openStream());
+        Attributes mainAttrs = mf.getMainAttributes();
+        if ("testng".equals(mainAttrs.getValue("Specification-Title"))) {
+          return toVersion(mainAttrs.getValue("Specification-Version"));
+        }
+
+        if ("org.testng".equals(mainAttrs.getValue("Bundle-SymbolicName"))) {
+          return toVersion(mainAttrs.getValue("Bundle-Version"));
+        }
+
+        if ("org.testng.TestNG".equals(mainAttrs.getValue("Main-Class"))) {
+          return toVersion(mainAttrs.getValue("Implementation-Version"));
+        }
+      }
+
+      return null;
+    }
+    
     private static void initAndRun(IRemoteTestNG remoteTestNg, String[] args, CommandLineArgs cla, RemoteArgs ra) {
         if (m_debug) {
             // In debug mode, override the port and the XML file to a fixed location
@@ -179,15 +245,6 @@ public class RemoteTestNG {
         if (isVerbose()) {
             System.out.println("[RemoteTestNG] " + s);
         }
-    }
-
-    private static String join(URL[] urls, String sep) {
-      StringBuilder sb = new StringBuilder();
-      for (URL url : urls) {
-        sb.append(url);
-        sb.append(sep);
-      }
-      return sb.toString();
     }
 
     private static Version toVersion(String strVer) {

--- a/remote/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/remote/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -115,7 +115,7 @@ public class RemoteTestNG {
       }
 
       throw new RuntimeException("Can't recognize the TestNG version on classpath."
-          + " Please make sure that there's a supported TestNG version (aka. >= 6.5.1) on your project.");
+          + " Please make sure that there's a supported TestNG version (aka. >= 6.0.0) on your project.");
     }
 
     /**

--- a/remote/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/remote/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -89,8 +89,10 @@ public class RemoteTestNG {
      * @throws RuntimeException if can't recognize the TestNG version on classpath. 
      */
     private static Version getTestNGVersion() {
+      String strVer = null;
       try {
-        return parseVersionFromClass();
+         strVer = getVersionFromClass();
+         return toVersion(strVer);
       } catch (Exception e) {
         if (isDebug()) {
           e.printStackTrace();
@@ -114,6 +116,11 @@ public class RemoteTestNG {
         }
       }
 
+      if (strVer != null && strVer.contains("DEV-SNAPSHOT")) {
+        // #36: for version contains DEV-SNAPSHOT, let ServiceLoaderHelper decide which Factory to use
+        return null;
+      }
+
       throw new RuntimeException("Can't recognize the TestNG version on classpath."
           + " Please make sure that there's a supported TestNG version (aka. >= 6.0.0) on your project.");
     }
@@ -128,13 +135,11 @@ public class RemoteTestNG {
      * @return
      * @throws Exception
      */
-    private static Version parseVersionFromClass() throws Exception {
+    private static String getVersionFromClass() throws Exception {
       @SuppressWarnings("rawtypes")
       Class clazz = Class.forName("org.testng.internal.Version");
       Field field = clazz.getDeclaredField("VERSION");
-      String strVer = (String) field.get(null);
-
-      return toVersion(strVer);
+      return (String) field.get(null);
     }
 
     /**

--- a/remote/src/main/java/org/testng/remote/support/RemoteTestNGFactory.java
+++ b/remote/src/main/java/org/testng/remote/support/RemoteTestNGFactory.java
@@ -2,8 +2,9 @@ package org.testng.remote.support;
 
 import org.osgi.framework.Version;
 import org.testng.remote.IRemoteTestNG;
+import org.testng.remote.Orderable;
 
-public interface RemoteTestNGFactory {
+public interface RemoteTestNGFactory extends Orderable {
 
     boolean accept(Version version);
     IRemoteTestNG createRemoteTestNG();

--- a/remote/src/main/java/org/testng/remote/support/ServiceLoaderHelper.java
+++ b/remote/src/main/java/org/testng/remote/support/ServiceLoaderHelper.java
@@ -4,6 +4,8 @@ import java.io.*;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -31,6 +33,15 @@ public final class ServiceLoaderHelper {
         if (factories.size() > 1) {
             System.err.println("[ServiceLoaderHelper] More than one working implementation for '" + version + "', we will use the first one");
         }
+
+        Collections.sort(factories, new Comparator<RemoteTestNGFactory>() {
+          @Override
+          public int compare(RemoteTestNGFactory o1, RemoteTestNGFactory o2) {
+            // the newest first
+            return o2.getOrder() - o1.getOrder();
+          }
+        });
+
         return factories.get(0);
     }
 

--- a/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_0.java
+++ b/remote6_0/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_0.java
@@ -20,4 +20,9 @@ public class RemoteTestNGFactory6_0 extends AbstractRemoteTestNGFactory {
   protected VersionRange getAcceptableVersions() {
     return RANGE;
   }
+
+  @Override
+  public int getOrder() {
+    return 1;
+  }
 }

--- a/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_5.java
+++ b/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_5.java
@@ -20,4 +20,9 @@ public class RemoteTestNGFactory6_5 extends AbstractRemoteTestNGFactory {
   protected VersionRange getAcceptableVersions() {
     return RANGE;
   }
+
+  @Override
+  public int getOrder() {
+    return 2;
+  }
 }

--- a/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_10.java
+++ b/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_10.java
@@ -20,4 +20,9 @@ public class RemoteTestNGFactory6_9_10 extends AbstractRemoteTestNGFactory {
   protected VersionRange getAcceptableVersions() {
     return RANGE;
   }
+
+  @Override
+  public int getOrder() {
+    return 4;
+  }
 }

--- a/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_7.java
+++ b/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNGFactory6_9_7.java
@@ -20,4 +20,9 @@ public class RemoteTestNGFactory6_9_7 extends AbstractRemoteTestNGFactory {
   protected VersionRange getAcceptableVersions() {
     return RANGE;
   }
+
+  @Override
+  public int getOrder() {
+    return 3;
+  }
 }


### PR DESCRIPTION
fixed #36 

since we lost the version when `DEV-VERSION` in introduce where we do need get the exact version of TestNG, so the solution here is to parse from MANIFEST.MF