### PR TITLE
explicitly add IConfigurationListener to TestRunner

### DIFF
--- a/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNG6_5.java
+++ b/remote6_5/src/main/java/org/testng/remote/support/RemoteTestNG6_5.java
@@ -2,6 +2,7 @@ package org.testng.remote.support;
 
 import java.util.List;
 
+import org.testng.IConfigurationListener;
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ITestRunnerFactory;
@@ -29,6 +30,9 @@ public class RemoteTestNG6_5 extends AbstractRemoteTestNG {
           if (m_useDefaultListeners) {
             runner.addListener(new TestHTMLReporter());
             runner.addListener(new JUnitXMLReporter());
+          }
+          for (IConfigurationListener cl : getConfiguration().getConfigurationListeners()) {
+            runner.addListener(cl);
           }
 
           return runner;

--- a/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNG6_9_10.java
+++ b/remote6_9_10/src/main/java/org/testng/remote/support/RemoteTestNG6_9_10.java
@@ -1,6 +1,7 @@
 package org.testng.remote.support;
 
 import org.testng.IClassListener;
+import org.testng.IConfigurationListener;
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ITestRunnerFactory;
@@ -31,6 +32,9 @@ public class RemoteTestNG6_9_10 extends AbstractRemoteTestNG {
             if (m_useDefaultListeners) {
               runner.addListener(new TestHTMLReporter());
               runner.addListener(new JUnitXMLReporter());
+            }
+            for (IConfigurationListener cl : getConfiguration().getConfigurationListeners()) {
+              runner.addListener(cl);
             }
 
             return runner;

--- a/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNG6_9_7.java
+++ b/remote6_9_7/src/main/java/org/testng/remote/support/RemoteTestNG6_9_7.java
@@ -1,5 +1,6 @@
 package org.testng.remote.support;
 
+import org.testng.IConfigurationListener;
 import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ITestRunnerFactory;
@@ -29,6 +30,9 @@ public class RemoteTestNG6_9_7 extends AbstractRemoteTestNG {
             if (m_useDefaultListeners) {
               runner.addListener(new TestHTMLReporter());
               runner.addListener(new JUnitXMLReporter());
+            }
+            for (IConfigurationListener cl : getConfiguration().getConfigurationListeners()) {
+              runner.addListener(cl);
             }
 
             return runner;


### PR DESCRIPTION
fixed https://github.com/cbeust/testng-eclipse/issues/298

this is a workaround that fix at testng-remote side, in essentially, need properly fixed at testng.

ping @cbeust , @juherr 