### PR TITLE
enable java9 build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+sudo: required
+dist: trusty
 language: java
 jdk:
+  - oraclejdk9
   - oraclejdk8
   - oraclejdk7
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
+
+before_install: export MAVEN_SKIP_RC=true
+
 after_success:
   - mkdir ~/.groovy
   - cp -f remote-test/src/test/resources/grapeConfig.xml ~/.groovy

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.5.201505241946</version>
+                <version>0.7.9</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/remote-test/src/test/groovy/Tester.groovy
+++ b/remote-test/src/test/groovy/Tester.groovy
@@ -1,5 +1,5 @@
 @Grab(group = 'org.osgi', module = 'osgi.core', version = '6.0.0')
-@Grab(group = 'org.testng.testng-remote', module = 'testng-remote', version = '1.2.1-SNAPSHOT')
+@Grab(group = 'org.testng.testng-remote', module = 'testng-remote', version = '1.3.0-SNAPSHOT')
 
 import org.osgi.framework.Version
 import org.testng.remote.strprotocol.JsonMessageSender


### PR DESCRIPTION
just try to experiment with java9 build in travis-ci, and have a view how does testng-remote work on java9.

ping @juherr 