### PR TITLE
#48: travis-ci renamed '9-ea' to '9'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install: echo "skip 'mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -
 script:
   - mkdir -p ~/.groovy
   - cp -f remote-test/src/test/resources/grapeConfig.xml ~/.groovy
-  - if [[ "$JAVA_VER" == "9-ea" ]]; then mvn -e -DskipIntTest=false clean install jacoco:report; else mvn -e -DskipIntTest=false clean install jacoco:report coveralls:report; fi
+  - if [[ "$JAVA_VER" == "9" ]]; then mvn -e -DskipIntTest=false clean install jacoco:report; else mvn -e -DskipIntTest=false clean install jacoco:report coveralls:report; fi
 
 after_success:
   - cp -f dist/settings.xml ~/.m2


### PR DESCRIPTION
closes #48 
trautonen/coveralls-maven-plugin was disabled on jdk9 due to the compatibility issue.
now travis-ci renamed version of jdk9 from '9-ea' to '9', let's follow that