### PR TITLE
blacklist the bad beta release 7.0.0-beta2

### DIFF
--- a/remote-test/src/test/groovy/Tester.groovy
+++ b/remote-test/src/test/groovy/Tester.groovy
@@ -48,7 +48,7 @@ resultSet = new HashMap<Integer, Set>()
 def startTime = System.currentTimeMillis()
 def metadata = new XmlSlurper().parse("https://bintray.com/cbeust/maven/download_file?file_path=org%2Ftestng%2Ftestng%2Fmaven-metadata.xml")
 
-def versionBlackList = ['6.14.0-RC2', '6.14.0-RC3']
+def versionBlackList = ['6.14.0-RC2', '6.14.0-RC3', '7.0.0-beta2']
 if (System.getProperty('java.version').startsWith('1.7')) {
     versionBlackList.add('7.*')
 }


### PR DESCRIPTION
the bad beta release 7.0.0-beta2 failed the test:

```
[RemoteTestNG] loaded class org.testng.internal.Version at file:/home/travis/.groovy/grapes/org.testng/testng/jars/testng-7.0.0-beta2.jar
[RemoteTestNG] detected TestNG version 7.0.0
Caught: java.lang.NoClassDefFoundError: org/testng/TestNG
java.lang.NoClassDefFoundError: org/testng/TestNG
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:801)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:699)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:622)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:185)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:801)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:699)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:622)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:185)
	at org.testng.remote.support.RemoteTestNGFactory6_12.createRemoteTestNG(RemoteTestNGFactory6_12.java:16)
	at org.testng.remote.RemoteTestNG.main(RemoteTestNG.java:67)
	at org.testng.remote.RemoteTestNG$main.call(Unknown Source)
	at TestNGTest.run(TestNGTest.groovy:49)
Caused by: java.lang.ClassNotFoundException: org.testng.TestNG
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:582)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:185)
	... 14 more
[BaseMessageSender] Stopped receiver
<<<<<
>>>>> Tested 7.0.0-beta2: result=2
<<<<<

Completed in 611165 (ms)
Summary report:
0 - PASSED:
	[6.0, 6.0.1, 6.1, 6.1.1, 6.2, 6.2.1, 6.3, 6.3.1, 6.4, 6.5.1, 6.5.2, 6.6, 6.7, 6.8, 6.8.1, 6.8.3, 6.8.5, 6.8.7, 6.8.8, 6.8.13, 6.8.14, 6.8.15, 6.8.17, 6.8.21, 6.9.4, 6.9.5, 6.9.7, 6.9.8, 6.9.9, 6.9.10, 6.9.11, 6.9.12, 6.9.13, 6.9.13.1, 6.9.13.2, 6.9.13.3, 6.9.13.4, 6.9.13.5, 6.9.13.6, 6.9.13.7, 6.9.13.8, 6.10, 6.11, 6.12, 6.13-RC1, 6.13-RC2, 6.13, 6.13.1, 6.14.0-RC1, 6.14.0-RC4, 6.14.0, 6.14.1, 6.14.2, 6.14.3, 7.0.0-beta1]
1 - unsupported version detected:
	[5.13, 5.13.1, 5.14, 5.14.1, 5.14.2, 5.14.3, 5.14.4, 5.14.5, 5.14.6, 5.14.7, 5.14.9, 5.14.10]
2 - NoClassDefFoundError:
	[4.4.7, 4.6.1, 4.7, 5.0, 5.0.1, 5.0.2, 5.1, 5.5, 5.5.m, 5.6, 5.7, 5.8, 5.9, 5.10, 5.11, 5.12.1, 7.0.0-beta2]
Caught: Assertion failed: 
assert (toVersion(it.toString()).compareTo(minVer) < 0)
        |         |  |           |         |       |
        7.0.0     |  7.0.0-beta2 1         6.0.0   false
                  7.0.0-beta2
Assertion failed: 
assert (toVersion(it.toString()).compareTo(minVer) < 0)
        |         |  |           |         |       |
        7.0.0     |  7.0.0-beta2 1         6.0.0   false
                  7.0.0-beta2
```