### PR TITLE
ci: fix CI failure

### DIFF
--- a/remote-test/src/test/groovy/Tester.groovy
+++ b/remote-test/src/test/groovy/Tester.groovy
@@ -1,5 +1,5 @@
 @Grab(group = 'org.osgi', module = 'osgi.core', version = '6.0.0')
-@Grab(group = 'org.testng.testng-remote', module = 'testng-remote', version = '1.4.0')
+@Grab(group = 'org.testng.testng-remote', module = 'testng-remote', version = '1.5.1')
 
 import org.osgi.framework.Version
 import org.testng.remote.strprotocol.JsonMessageSender
@@ -13,7 +13,7 @@ classifierVer = new Version("5.11")
 
 groovyVer = System.getProperty("GROOVY_VERSION") ?: "2.3.11"
 ivyVer = System.getProperty("IVY_VERSION") ?: "2.3.0"
-testngRemoteVer = System.getProperty("PROJECT_VERSION") ?: "1.4.0"
+testngRemoteVer = System.getProperty("PROJECT_VERSION") ?: "1.5.1"
 jcmdVer = "1.48"
 slf4jVer = "1.7.32"
 


### PR DESCRIPTION
java.lang.RuntimeException: Error grabbing Grapes -- [unresolved dependency: org.testng.testng-remote#testng-remote;1.4.0: not found]